### PR TITLE
Logger rewrite

### DIFF
--- a/Grabacr07.KanColleWrapper/Logger.cs
+++ b/Grabacr07.KanColleWrapper/Logger.cs
@@ -22,6 +22,7 @@ namespace Grabacr07.KanColleWrapper
         private bool waitingForShip;
         private int dockid;
         private readonly int[] shipmats;
+        private int secretary;
 
         protected enum LogType
         {
@@ -102,6 +103,7 @@ namespace Grabacr07.KanColleWrapper
                 return LogType.BuildShip;
             }
             public string Result { get; set; }
+            public int Secretary { get; set; }
             public int Fuel { get; set; }
             public int Ammo { get; set; }
             public int Steel { get; set; }
@@ -148,6 +150,7 @@ namespace Grabacr07.KanColleWrapper
         private void CreateShip(NameValueCollection req)
         {
             this.waitingForShip = true;
+            this.secretary = KanColleClient.Current.Homeport.Organization.Fleets[0].Ships[0].Info.SortId;
             this.dockid = Int32.Parse(req["api_kdock_id"]);
             this.shipmats[0] = Int32.Parse(req["api_item1"]);
             this.shipmats[1] = Int32.Parse(req["api_item2"]);
@@ -163,6 +166,7 @@ namespace Grabacr07.KanColleWrapper
                 var logitem = new BuildShip
                 {
                     Result = KanColleClient.Current.Master.Ships[dock.api_created_ship_id].Name,
+                    Secretary = this.secretary,
                     Fuel = this.shipmats[0],
                     Ammo = this.shipmats[1],
                     Steel = this.shipmats[2],

--- a/Grabacr07.KanColleWrapper/Logger.cs
+++ b/Grabacr07.KanColleWrapper/Logger.cs
@@ -21,36 +21,23 @@ namespace Grabacr07.KanColleWrapper
 
         private bool waitingForShip;
         private int dockid;
-        private readonly int[] shipmats;
-        private int secretary;
-
-        protected enum LogType
-        {
-            Invalid,
-            BuildItem,
-            BuildShip,
-            ShipDrop
-        };
+        private readonly Craft.Recipe recipe;
 
         protected class LogItem
         {
+
             public LogItem()
             {
                 Time = DateTime.Now;
             }
 
             public DateTime Time { get; set; }
-            //TODO: Probably needs a better way of doing this. Reflection vs abstract properties?
-            public virtual LogType Type()
-            {
-                return LogType.Invalid;
-            }
-
+            
             /// <summary>
             /// Create a CSV serialization of the current class.
             /// </summary>
             /// <returns>A csv string with serialized items. </returns>
-            public string ToCsv()
+            public virtual string ToCsv()
             {
                 PropertyInfo[] properties = this.GetType().GetProperties();
                 var sb = new StringBuilder();
@@ -66,7 +53,7 @@ namespace Grabacr07.KanColleWrapper
             /// 
             /// </summary>
             /// <returns></returns>
-            public string CsvTitle()
+            public virtual string CsvTitle()
             {
                 PropertyInfo[] properties = this.GetType().GetProperties();
                 var sb = new StringBuilder();
@@ -82,41 +69,37 @@ namespace Grabacr07.KanColleWrapper
             }
         }
 
-        protected class BuildItem : LogItem
+        protected class Craft : LogItem
         {
-            public override LogType Type()
+            public class Recipe
             {
-                return LogType.BuildItem;
+                public int Fuel { get; set; }
+                public int Ammo { get; set; }
+                public int Steel { get; set; }
+                public int Bauxite { get; set; }
+                public int BuildMaterials { get; set; }
             }
+            public Recipe CraftRecipe { get; set; }
+            public ShipInfo Secretary { get; set; }
+        }
+        //TODO: Rewrite
+        protected class BuildItem : Craft
+        {
             public string Result { get; set; }
-            public string Secretary { get; set; }
-            public string Fuel { get; set; }
-            public string Ammo { get; set; }
-            public string Steel { get; set; }
-            public string Bauxite { get; set; }
         }
 
-        protected class BuildShip : LogItem
+        protected class BuildShip : Craft
         {
-            public override LogType Type()
+            public ShipInfo Result { get; set; }
+            public override string ToCsv()
             {
-                return LogType.BuildShip;
+
+                return base.ToCsv();
             }
-            public string Result { get; set; }
-            public int Secretary { get; set; }
-            public int Fuel { get; set; }
-            public int Ammo { get; set; }
-            public int Steel { get; set; }
-            public int Bauxite { get; set; }
-            public int BuildMaterials { get; set; }
         }
 
         protected class ShipDrop : LogItem
         {
-            public override LogType Type()
-            {
-                return LogType.ShipDrop;
-            }
             public string Result { get; set; }
             public string Operation { get; set; }
             public string EnemyFleet { get; set; }
@@ -125,8 +108,7 @@ namespace Grabacr07.KanColleWrapper
 
         internal Logger(KanColleProxy proxy)
         {
-            this.shipmats = new int[5];
-
+            recipe = new Craft.Recipe();
             // ちょっと考えなおす
             proxy.api_req_kousyou_createitem.TryParse<kcsapi_createitem>().Subscribe(x => this.CreateItem(x.Data, x.Request));
             proxy.api_req_kousyou_createship.TryParse<kcsapi_createship>().Subscribe(x => this.CreateShip(x.Request));
@@ -136,13 +118,17 @@ namespace Grabacr07.KanColleWrapper
 
         private void CreateItem(kcsapi_createitem item, NameValueCollection req)
         {
+            this.recipe.Fuel = Int32.Parse(req["api_item1"]);
+            this.recipe.Ammo = Int32.Parse(req["api_item2"]);
+            this.recipe.Steel = Int32.Parse(req["api_item3"]);
+            this.recipe.Bauxite = Int32.Parse(req["api_item4"]);
+            this.recipe.BuildMaterials = Int32.Parse(req["api_item5"]);
+
             var logitem = new BuildItem
             {
                 Result = item.api_create_flag == 1 ? KanColleClient.Current.Master.SlotItems[item.api_slot_item.api_slotitem_id].Name : "Penguin",
-                Fuel = req["api_item1"],
-                Ammo = req["api_item2"],
-                Steel = req["api_item3"],
-                Bauxite = req["api_item4"],
+                Secretary = KanColleClient.Current.Homeport.Organization.Fleets[1].Ships[0].Info,
+                CraftRecipe = this.recipe
             };
             Log(logitem);
         }
@@ -150,13 +136,13 @@ namespace Grabacr07.KanColleWrapper
         private void CreateShip(NameValueCollection req)
         {
             this.waitingForShip = true;
-            this.secretary = KanColleClient.Current.Homeport.Organization.Fleets[0].Ships[0].Info.SortId;
             this.dockid = Int32.Parse(req["api_kdock_id"]);
-            this.shipmats[0] = Int32.Parse(req["api_item1"]);
-            this.shipmats[1] = Int32.Parse(req["api_item2"]);
-            this.shipmats[2] = Int32.Parse(req["api_item3"]);
-            this.shipmats[3] = Int32.Parse(req["api_item4"]);
-            this.shipmats[4] = Int32.Parse(req["api_item5"]);
+
+            this.recipe.Fuel = Int32.Parse(req["api_item1"]);
+            this.recipe.Ammo = Int32.Parse(req["api_item2"]);
+            this.recipe.Steel = Int32.Parse(req["api_item3"]);
+            this.recipe.Bauxite = Int32.Parse(req["api_item4"]);
+            this.recipe.BuildMaterials = Int32.Parse(req["api_item5"]);
         }
 
         private void KDock(kcsapi_kdock[] docks)
@@ -165,14 +151,9 @@ namespace Grabacr07.KanColleWrapper
             {
                 var logitem = new BuildShip
                 {
-                    Result = KanColleClient.Current.Master.Ships[dock.api_created_ship_id].Name,
-                    Secretary = this.secretary,
-                    Fuel = this.shipmats[0],
-                    Ammo = this.shipmats[1],
-                    Steel = this.shipmats[2],
-                    Bauxite = this.shipmats[3],
-                    BuildMaterials = this.shipmats[4]
-
+                    Result = KanColleClient.Current.Master.Ships[dock.api_created_ship_id],
+                    Secretary = KanColleClient.Current.Homeport.Organization.Fleets[1].Ships[0].Info,
+                    CraftRecipe = this.recipe
                 };
                 Log(logitem);
                 this.waitingForShip = false;
@@ -202,15 +183,15 @@ namespace Grabacr07.KanColleWrapper
                 string mainFolder = Path.GetDirectoryName(System.Reflection.Assembly.GetEntryAssembly().Location);
 
                 string logpath;
-                switch (item.Type())
+                switch (item.GetType().ToString())
                 {
-                    case LogType.BuildItem:
+                    case "BuildItem":
                         logpath = mainFolder + "\\ItemBuildLog.csv";
                         break;
-                    case LogType.BuildShip:
+                    case "BuildShip":
                         logpath = mainFolder + "\\ShipBuildLog.csv";
                         break;
-                    case LogType.ShipDrop:
+                    case "ShipDrop":
                         logpath = mainFolder + "\\DropLog.csv";
                         break;
                     default:

--- a/Grabacr07.KanColleWrapper/Logger.cs
+++ b/Grabacr07.KanColleWrapper/Logger.cs
@@ -15,21 +15,21 @@ using Livet;
 
 namespace Grabacr07.KanColleWrapper
 {
-	public class Logger : NotificationObject
-	{
-		public bool EnableLogging { get; set; }
+    public class Logger : NotificationObject
+    {
+        public bool EnableLogging { get; set; }
 
-		private bool waitingForShip;
-		private int dockid;
-		private readonly int[] shipmats;
+        private bool waitingForShip;
+        private int dockid;
+        private readonly int[] shipmats;
 
-	    protected enum LogType
-		{
+        protected enum LogType
+        {
             Invalid,
-			BuildItem,
-			BuildShip,
-			ShipDrop
-		};
+            BuildItem,
+            BuildShip,
+            ShipDrop
+        };
 
         protected class LogItem
         {
@@ -39,8 +39,10 @@ namespace Grabacr07.KanColleWrapper
             }
 
             public DateTime Time { get; set; }
-            public LogType Type {
-                get { return LogType.Invalid; }
+            //TODO: Probably needs a better way of doing this. Reflection vs abstract properties?
+            public virtual LogType Type()
+            {
+                return LogType.Invalid;
             }
 
             /// <summary>
@@ -51,7 +53,7 @@ namespace Grabacr07.KanColleWrapper
             {
                 PropertyInfo[] properties = this.GetType().GetProperties();
                 var sb = new StringBuilder();
-                foreach(var prp in properties)
+                foreach (var prp in properties)
                 {
                     sb.Append(prp.GetValue(this, null)).Append(',');
                 }
@@ -81,113 +83,113 @@ namespace Grabacr07.KanColleWrapper
 
         protected class BuildItem : LogItem
         {
-            public new LogType Type
+            public override LogType Type()
             {
-                get { return LogType.BuildItem; }
+                return LogType.BuildItem;
             }
-            public string Result {get; set;}
-            public string Secretary {get; set;}
-            public string Fuel {get; set;}
+            public string Result { get; set; }
+            public string Secretary { get; set; }
+            public string Fuel { get; set; }
             public string Ammo { get; set; }
             public string Steel { get; set; }
-            public string Bauxite {get; set;}
+            public string Bauxite { get; set; }
         }
 
         protected class BuildShip : LogItem
         {
-            public new LogType Type
+            public override LogType Type()
             {
-                get { return LogType.BuildShip; }
+                return LogType.BuildShip;
             }
             public string Result { get; set; }
-            public int Fuel {get; set;}
-            public int Ammo {get; set;}
-            public int Steel {get; set; }
-            public int Bauxite {get; set; }
+            public int Fuel { get; set; }
+            public int Ammo { get; set; }
+            public int Steel { get; set; }
+            public int Bauxite { get; set; }
             public int BuildMaterials { get; set; }
         }
 
         protected class ShipDrop : LogItem
         {
-            public new LogType Type
+            public override LogType Type()
             {
-                get { return LogType.ShipDrop; }
+                return LogType.ShipDrop;
             }
-            public string Result {get; set;}
-            public string Operation {get; set;}
-            public string EnemyFleet {get; set;}
-            public string Rank {get; set;}
+            public string Result { get; set; }
+            public string Operation { get; set; }
+            public string EnemyFleet { get; set; }
+            public string Rank { get; set; }
         }
 
-		internal Logger(KanColleProxy proxy)
-		{
-			this.shipmats = new int[5];
+        internal Logger(KanColleProxy proxy)
+        {
+            this.shipmats = new int[5];
 
-			// ちょっと考えなおす
-			proxy.api_req_kousyou_createitem.TryParse<kcsapi_createitem>().Subscribe(x => this.CreateItem(x.Data, x.Request));
-			proxy.api_req_kousyou_createship.TryParse<kcsapi_createship>().Subscribe(x => this.CreateShip(x.Request));
-			proxy.api_get_member_kdock.TryParse<kcsapi_kdock[]>().Subscribe(x => this.KDock(x.Data));
-			proxy.api_req_sortie_battleresult.TryParse<kcsapi_battleresult>().Subscribe(x => this.BattleResult(x.Data));
-		}
-		
-		private void CreateItem(kcsapi_createitem item, NameValueCollection req)
-		{
-		    var logitem = new BuildItem
-		    {
-		        Result = item.api_create_flag == 1 ? KanColleClient.Current.Master.SlotItems[item.api_slot_item.api_slotitem_id].Name : "Penguin",
-		        Fuel = req["api_item1"],
-		        Ammo = req["api_item2"],
-		        Steel = req["api_item3"],
-		        Bauxite = req["api_item4"],
-		    };
-		    Log(logitem);
-		}
+            // ちょっと考えなおす
+            proxy.api_req_kousyou_createitem.TryParse<kcsapi_createitem>().Subscribe(x => this.CreateItem(x.Data, x.Request));
+            proxy.api_req_kousyou_createship.TryParse<kcsapi_createship>().Subscribe(x => this.CreateShip(x.Request));
+            proxy.api_get_member_kdock.TryParse<kcsapi_kdock[]>().Subscribe(x => this.KDock(x.Data));
+            proxy.api_req_sortie_battleresult.TryParse<kcsapi_battleresult>().Subscribe(x => this.BattleResult(x.Data));
+        }
 
-		private void CreateShip(NameValueCollection req)
-		{
-			this.waitingForShip = true;
-			this.dockid = Int32.Parse(req["api_kdock_id"]);
-			this.shipmats[0] = Int32.Parse(req["api_item1"]);
-			this.shipmats[1] = Int32.Parse(req["api_item2"]);
-			this.shipmats[2] = Int32.Parse(req["api_item3"]);
-			this.shipmats[3] = Int32.Parse(req["api_item4"]);
-			this.shipmats[4] = Int32.Parse(req["api_item5"]);
-		}
+        private void CreateItem(kcsapi_createitem item, NameValueCollection req)
+        {
+            var logitem = new BuildItem
+            {
+                Result = item.api_create_flag == 1 ? KanColleClient.Current.Master.SlotItems[item.api_slot_item.api_slotitem_id].Name : "Penguin",
+                Fuel = req["api_item1"],
+                Ammo = req["api_item2"],
+                Steel = req["api_item3"],
+                Bauxite = req["api_item4"],
+            };
+            Log(logitem);
+        }
 
-		private void KDock(kcsapi_kdock[] docks)
-		{
-			foreach (var dock in docks.Where(dock => this.waitingForShip && dock.api_id == this.dockid))
-			{
-			    var logitem = new BuildShip
-			    {
-			        Result = KanColleClient.Current.Master.Ships[dock.api_created_ship_id].Name,
-			        Fuel = this.shipmats[0],
-			        Ammo = this.shipmats[1],
-			        Steel = this.shipmats[2],
-			        Bauxite = this.shipmats[3],
-			        BuildMaterials = this.shipmats[4]
+        private void CreateShip(NameValueCollection req)
+        {
+            this.waitingForShip = true;
+            this.dockid = Int32.Parse(req["api_kdock_id"]);
+            this.shipmats[0] = Int32.Parse(req["api_item1"]);
+            this.shipmats[1] = Int32.Parse(req["api_item2"]);
+            this.shipmats[2] = Int32.Parse(req["api_item3"]);
+            this.shipmats[3] = Int32.Parse(req["api_item4"]);
+            this.shipmats[4] = Int32.Parse(req["api_item5"]);
+        }
 
-			    };
-			    Log(logitem);
-				this.waitingForShip = false;
-			}
-		}
+        private void KDock(kcsapi_kdock[] docks)
+        {
+            foreach (var dock in docks.Where(dock => this.waitingForShip && dock.api_id == this.dockid))
+            {
+                var logitem = new BuildShip
+                {
+                    Result = KanColleClient.Current.Master.Ships[dock.api_created_ship_id].Name,
+                    Fuel = this.shipmats[0],
+                    Ammo = this.shipmats[1],
+                    Steel = this.shipmats[2],
+                    Bauxite = this.shipmats[3],
+                    BuildMaterials = this.shipmats[4]
 
-	    private void BattleResult(kcsapi_battleresult br)
-	    {
-	        if (br.api_get_ship == null)
-	            return;
-	        var logitem = new ShipDrop
-	        {
-	            Result = KanColleClient.Current.Translations.GetTranslation(br.api_get_ship.api_ship_name, TranslationType.Ships, br),
-	            Operation = KanColleClient.Current.Translations.GetTranslation(br.api_quest_name, TranslationType.OperationMaps, br),
-	            EnemyFleet = KanColleClient.Current.Translations.GetTranslation(br.api_enemy_info.api_deck_name, TranslationType.OperationSortie, br),
-	            Rank = br.api_win_rank
-	        };
-	        Log(logitem);
-	    }
+                };
+                Log(logitem);
+                this.waitingForShip = false;
+            }
+        }
 
-	    protected virtual void Log(LogItem item)
+        private void BattleResult(kcsapi_battleresult br)
+        {
+            if (br.api_get_ship == null)
+                return;
+            var logitem = new ShipDrop
+            {
+                Result = KanColleClient.Current.Translations.GetTranslation(br.api_get_ship.api_ship_name, TranslationType.Ships, br),
+                Operation = KanColleClient.Current.Translations.GetTranslation(br.api_quest_name, TranslationType.OperationMaps, br),
+                EnemyFleet = KanColleClient.Current.Translations.GetTranslation(br.api_enemy_info.api_deck_name, TranslationType.OperationSortie, br),
+                Rank = br.api_win_rank
+            };
+            Log(logitem);
+        }
+
+        protected virtual void Log(LogItem item)
         {
             if (!this.EnableLogging) return;
 
@@ -196,7 +198,7 @@ namespace Grabacr07.KanColleWrapper
                 string mainFolder = Path.GetDirectoryName(System.Reflection.Assembly.GetEntryAssembly().Location);
 
                 string logpath;
-                switch (item.Type)
+                switch (item.Type())
                 {
                     case LogType.BuildItem:
                         logpath = mainFolder + "\\ItemBuildLog.csv";
@@ -217,7 +219,7 @@ namespace Grabacr07.KanColleWrapper
                         w.WriteLine(item.CsvTitle());
                     }
                 }
-                using(var w = File.AppendText(logpath))
+                using (var w = File.AppendText(logpath))
                 {
                     w.WriteLine(item.ToCsv());
                 }
@@ -227,5 +229,5 @@ namespace Grabacr07.KanColleWrapper
                 Debug.WriteLine(ex);
             }
         }
-	}
+    }
 }

--- a/Grabacr07.KanColleWrapper/Logger.cs
+++ b/Grabacr07.KanColleWrapper/Logger.cs
@@ -187,7 +187,7 @@ namespace Grabacr07.KanColleWrapper
 	        Log(logitem);
 	    }
 
-	    protected void Log(LogItem item)
+	    protected virtual void Log(LogItem item)
         {
             if (!this.EnableLogging) return;
 


### PR DESCRIPTION
Drop in logger, rewritten to be more extensible (albeit longer).
Rudimentary support for templating through reflection, allowing custom logging by the end user. This also allows everything to be easily serialized for other formats.

Titles might have been changed a little, but the order of CSV entries should be the same.

Moderately tested, but it looks like sortie logging is broken (even on your latest).